### PR TITLE
LAFF transformer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip pytest
-        pip install pyterrier_pisa torch --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install pyterrier_pisa torch transformers --extra-index-url https://download.pytorch.org/whl/cpu
         pip install --upgrade --upgrade-strategy eager -r requirements.txt
         
     - name: Run tests

--- a/pyterrier_adaptive/__init__.py
+++ b/pyterrier_adaptive/__init__.py
@@ -1,4 +1,5 @@
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 from .gar import GAR
 from .corpus_graph import CorpusGraph
+from pyterrier_adaptive._laff import Laff

--- a/pyterrier_adaptive/__init__.py
+++ b/pyterrier_adaptive/__init__.py
@@ -1,5 +1,5 @@
 __version__ = '0.2.0'
 
 from .gar import GAR
-from .corpus_graph import CorpusGraph
+from .corpus_graph import CorpusGraph, NpTopKCorpusGraph
 from pyterrier_adaptive._laff import Laff

--- a/pyterrier_adaptive/_laff.py
+++ b/pyterrier_adaptive/_laff.py
@@ -80,7 +80,7 @@ class Laff(pt.Transformer):
                 return_tensors='pt',
             ).to(self.device)
 
-            with torch.no_grad():
+            with torch.no_grad(), torch.autocast(device_type=self.device.type):
                 outputs = self.model(**enc)
                 affinity_scores += outputs.logits.flatten().tolist()
 

--- a/pyterrier_adaptive/_laff.py
+++ b/pyterrier_adaptive/_laff.py
@@ -36,7 +36,7 @@ class Laff(pt.Transformer):
         self.max_length = max_length
         self.verbose = verbose
 
-    def compute_affinity_scores(self,
+    def compute_affinity(self,
         texts_left: Union[str, List[str]],
         texts_right: Union[str, List[str]]
     ) -> List[float]:
@@ -50,8 +50,7 @@ class Laff(pt.Transformer):
             A list of affinity scores.
         """
         if isinstance(texts_left, str) and isinstance(texts_right, str):
-            texts_left = [texts_left]
-            texts_right = [texts_right]
+            return self.compute_affinity([texts_left], [texts_right])[0]
         elif isinstance(texts_left, str):
             texts_left = [texts_left] * len(texts_right)
         elif isinstance(texts_right, str):
@@ -91,7 +90,7 @@ class Laff(pt.Transformer):
         Results are sorted by the left-side text and the affinity score.
         """
         pta.validate.columns(inp, includes=['text', 'other_text'])
-        affinity_scores = self.compute_affinity_scores(inp['text'], inp['other_text'])
-        res = inp.assign(affinity_score=affinity_scores)
-        res.sort_values(['text', 'affinity_score'], ascending=[True, False], inplace=True)
+        affinity = self.compute_affinity(inp['text'], inp['other_text'])
+        res = inp.assign(affinity=affinity)
+        res.sort_values(['text', 'affinity'], ascending=[True, False], inplace=True)
         return res

--- a/pyterrier_adaptive/_laff.py
+++ b/pyterrier_adaptive/_laff.py
@@ -1,0 +1,97 @@
+from typing import Optional, Union, List
+import torch
+import pandas as pd
+from tqdm import tqdm
+from more_itertools import chunked
+import pyterrier as pt
+import pyterrier_alpha as pta
+
+
+class Laff(pt.Transformer):
+    """A transformer that computes a learned affinity score between two document texts using a transformer model. """
+
+    def __init__(self,
+        model: str = 'macavaney/laff',
+        *,
+        device: Optional[Union[str, torch.device]] = None,
+        batch_size: int = 128,
+        max_length: int = 512,
+        verbose: bool = False
+    ):
+        """ Initialize the LAFF transformer.
+
+        Args:
+            model: the name of the transformer model to use.
+            device: the device to use for the transformer model.
+            batch_size: the batch size to use for processing.
+            max_length: the maximum length of the input text.
+            verbose: whether to display progress bars.
+        """
+        from transformers import AutoModelForSequenceClassification, AutoTokenizer
+        self.model = AutoModelForSequenceClassification.from_pretrained(model)
+        self.tokenizer = AutoTokenizer.from_pretrained(model)
+        self.device = torch.device(device or ('cuda' if torch.cuda.is_available() else 'cpu'))
+        self.model = self.model.to(self.device)
+        self.batch_size = batch_size
+        self.max_length = max_length
+        self.verbose = verbose
+
+    def compute_affinity_scores(self,
+        texts_left: Union[str, List[str]],
+        texts_right: Union[str, List[str]]
+    ) -> List[float]:
+        """ Compute the affinity scores between two lists of texts.
+
+        Args:
+            texts_left: the left-hand side texts.
+            texts_right: the right-hand side texts.
+
+        Returns:
+            A list of affinity scores.
+        """
+        if isinstance(texts_left, str) and isinstance(texts_right, str):
+            texts_left = [texts_left]
+            texts_right = [texts_right]
+        elif isinstance(texts_left, str):
+            texts_left = [texts_left] * len(texts_right)
+        elif isinstance(texts_right, str):
+            texts_right = [texts_right] * len(texts_left)
+        assert len(texts_left) == len(texts_right)
+
+        affinity_scores = []
+
+        it = chunked(zip(texts_left, texts_right), self.batch_size)
+        if self.verbose:
+            it = tqdm(it, unit='batch', total=len(texts_left))
+
+        for batch in it:
+            batch = list(batch)
+            batch_left, batch_right = zip(*batch)
+            enc = self.tokenizer(
+                list(batch_left),
+                list(batch_right),
+                max_length=self.max_length,
+                padding='max_length',
+                truncation=True,
+                return_attention_mask=True,
+                return_tensors='pt',
+            ).to(self.device)
+
+            with torch.no_grad():
+                outputs = self.model(**enc)
+                affinity_scores += outputs.logits.flatten().tolist()
+
+        return affinity_scores
+
+    def transform(self, inp: pd.DataFrame) -> pd.DataFrame:
+        """ Compute the affinity scores between two columns of texts in the input.
+
+        Expects columns ``text`` (for the left-side text) and ``other_text`` (for the right-side text).
+
+        Results are sorted by the left-side text and the affinity score.
+        """
+        pta.validate.columns(inp, includes=['text', 'other_text'])
+        affinity_scores = self.compute_affinity_scores(inp['text'], inp['other_text'])
+        res = inp.assign(affinity_score=affinity_scores)
+        res.sort_values(['text', 'affinity_score'], ascending=[True, False], inplace=True)
+        return res

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 python-terrier
 npids>=0.0.2
 pyterrier-alpha>=0.6.2
+torch
+pandas
+tqdm
+more_itertools

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ torch
 pandas
 tqdm
 more_itertools
-transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ torch
 pandas
 tqdm
 more_itertools
+transformers

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setuptools.setup(
             'corpus_graph.np_topk = pyterrier_adaptive.corpus_graph:NpTopKCorpusGraph',
         ],
     },
+    optional_dependencies={
+        'laff': ['transformers'],
+    },
     package_data={
         '': ['requirements.txt'],
     },

--- a/tests/test_laff.py
+++ b/tests/test_laff.py
@@ -1,0 +1,25 @@
+import unittest
+import pandas as pd
+from pyterrier_adaptive import Laff
+
+
+class TestLaff(unittest.TestCase):
+    def test_laff(self):
+        laff = Laff()
+        scores = laff.compute_affinity_scores("hello", "world")
+        self.assertEqual(len(scores), 1)
+
+        scores = laff.compute_affinity_scores(["hello", "world"], ["world", "hello"])
+        self.assertEqual(len(scores), 2)
+
+        inp = pd.DataFrame({
+            "text": ["hello", "world"],
+            "other_text": ["world", "hello"]
+        })
+        out = laff(inp)
+        self.assertEqual(len(out), 2)
+        self.assertTrue('affinity_score' in out.columns)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_laff.py
+++ b/tests/test_laff.py
@@ -6,11 +6,13 @@ from pyterrier_adaptive import Laff
 class TestLaff(unittest.TestCase):
     def test_laff(self):
         laff = Laff()
-        scores = laff.compute_affinity_scores("hello", "world")
-        self.assertEqual(len(scores), 1)
+        scores = laff.compute_affinity("hello", "world")
+        self.assertTrue(isinstance(scores, float))
 
-        scores = laff.compute_affinity_scores(["hello", "world"], ["world", "hello"])
+        scores = laff.compute_affinity(["hello", "world"], ["world", "hello"])
         self.assertEqual(len(scores), 2)
+        self.assertTrue(isinstance(scores[0], float))
+        self.assertTrue(isinstance(scores[1], float))
 
         inp = pd.DataFrame({
             "text": ["hello", "world"],
@@ -18,7 +20,7 @@ class TestLaff(unittest.TestCase):
         })
         out = laff(inp)
         self.assertEqual(len(out), 2)
-        self.assertTrue('affinity_score' in out.columns)
+        self.assertTrue('affinity' in out.columns)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@Mandeep-Rathee can you take a look to make sure this implementation looks right? It's based off the code [here](https://github.com/Mandeep-Rathee/quam/blob/main/base_models.py) and [here](https://github.com/Mandeep-Rathee/quam/blob/main/run.py).

I've also packaged up laff into a huggingface model at [macavaney/laff](https://huggingface.co/macavaney/laff) that allows it (and its tokenizer) to be loaded with `from_pretrained`, avoiding the stuff with `hf_hub_download`. Feel free to merge it into [mandeep-rathee/laff-model](https://huggingface.co/mandeep-rathee/laff-model) if you like and I'll drop mine.

The next step will be writing a method to apply to a corpus graph.